### PR TITLE
Signing message hash

### DIFF
--- a/crypto/public_key.go
+++ b/crypto/public_key.go
@@ -150,7 +150,7 @@ func (pb *PublicKey) EnsureValid() error {
 }
 
 func (pb PublicKey) Verify(msg []byte, signature Signature) bool {
-	return ed25519.Verify(pb.RawBytes(), msg, signature.RawBytes())
+	return ed25519.Verify(pb.RawBytes(), Sha3(msg), signature.RawBytes())
 }
 
 func (pb PublicKey) AccountAddress() Address {

--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -37,5 +37,6 @@ func (s *signer) PublicKey() PublicKey {
 }
 
 func (s *signer) Sign(msg []byte) (Signature, error) {
-	return s.privateKey.Sign(msg)
+	hash := Sha3(msg)
+	return s.privateKey.Sign(hash)
 }

--- a/crypto/signer_test.go
+++ b/crypto/signer_test.go
@@ -1,0 +1,17 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyingSignature(t *testing.T) {
+	msg := []byte("message")
+
+	pb, pv := GenerateKey(nil)
+	signer := NewAccountSigner(pv)
+	sig, err := signer.Sign(msg)
+	require.NoError(t, err)
+	require.True(t, pb.Verify(msg, sig))
+}


### PR DESCRIPTION
- Using message hash to sign the message (Note: EdVerify pre-compiled contract uses message hash to verify signature)