### PR TITLE
Fix linkage error after updating SputnikVm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,14 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
+    before_install: brew install gcc10
     script: make
   - os: osx
     go: master
+    before_install: brew install gcc10
     script: make
 
 install:
-- ls /System/Library/Frameworks
 - curl -sSf rustup-install.sh https://sh.rustup.rs > rustup-install.sh
 - sh rustup-install.sh -y
 - export PATH="$HOME/.cargo/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
-    before_install: brew install gcc10
+    before_install: brew install gcc
     script: make
   - os: osx
     go: master
-    before_install: brew install gcc10
+    before_install: brew install gcc
     script: make
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,12 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
-    install: brew install openssl
     script: make
   - os: osx
-    install: brew install openssl
     go: master
     script: make
 
-before_install:
+install:
 - curl -sSf rustup-install.sh https://sh.rustup.rs > rustup-install.sh
 - sh rustup-install.sh -y
 - export PATH="$HOME/.cargo/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
-    before_install: brew install gcc
+    before_install: brew install gcc && gcc --version && brew install llvm
     script: make
   - os: osx
     go: master
-    before_install: brew install gcc
+    before_install: brew install gcc && gcc --version && brew install llvm
     script: make
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,14 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
+    install: brew install openssl
     script: make
   - os: osx
+    install: brew install openssl
     go: master
     script: make
 
-install:
+before_install:
 - curl -sSf rustup-install.sh https://sh.rustup.rs > rustup-install.sh
 - sh rustup-install.sh -y
 - export PATH="$HOME/.cargo/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
-    before_install: brew install gcc && gcc --version && brew install llvm
+    before_install:
+      - brew install gcc
+      - gcc --version
+      - brew install llvm
     script: make
   - os: osx
     go: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     script: make
 
 install:
+- ls /System/Library/Frameworks
 - curl -sSf rustup-install.sh https://sh.rustup.rs > rustup-install.sh
 - sh rustup-install.sh -y
 - export PATH="$HOME/.cargo/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,9 @@ matrix:
     script: make
   - os: osx
     go: 1.10.x
-    before_install:
-      - brew install gcc
-      - gcc --version
-      - brew install llvm
     script: make
   - os: osx
     go: master
-    before_install: brew install gcc && gcc --version && brew install llvm
     script: make
 
 install:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -645,7 +645,6 @@
     "github.com/gin-gonic/gin",
     "github.com/go-kit/kit/log",
     "github.com/gogo/protobuf/gogoproto",
-    "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes/struct",
     "github.com/hyperledger/burrow/logging",

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
 LDFLAGS= -ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lm"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lm"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -L./libs/mac -lcrypto -lssl -lm"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lpthread -lm"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm -lresolv"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm -lz"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOTOOLS = \
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
-LDFLAGS= -ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
+LDFLAGS=-framework CoreServices -framework Foundation -framework Security -ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
 
@@ -18,7 +18,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -framework Security"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -framework CoreServices -framework Foundation -framework Security"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOTOOLS = \
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
-LDFLAGS=-framework CoreServices -framework Foundation -framework Security -ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
+LDFLAGS=-ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`" "-framework CoreServices -framework Foundation -framework Security"
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+UNAME := $(shell uname)
 GOTOOLS = \
 	github.com/golang/dep/cmd/dep \
 	gopkg.in/alecthomas/gometalinter.v2 \
@@ -10,8 +11,14 @@ PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
 LDFLAGS= -ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
+
+ifeq ($(UNAME), Linux)
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
+endif
+ifeq ($(UNAME), Darwin)
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lpthread -lm"
+endif
 
 all: tools deps build install test test_release proto
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
 LDFLAGS= -ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lm"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm -lresolv"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lm"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOTOOLS = \
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
-LDFLAGS=-ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`" "-framework CoreServices -framework Foundation -framework Security"
+LDFLAGS=-ldflags "-framework CoreServices -framework Foundation -framework Security" "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -L./libs/mac -lcrypto -lssl -lm"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm -lz"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
+CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -framework Security"
 endif
 
 all: tools deps build install test test_release proto

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOTOOLS = \
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 SPUTNIKVM_PATH = $(GOPATH)/src/github.com/gallactic/sputnikvm-ffi
 TAGS=-tags 'gallactic'
-LDFLAGS=-ldflags "-framework CoreServices -framework Foundation -framework Security" "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
+LDFLAGS=-ldflags "-X github.com/gallactic/gallactic/version.GitCommit=`git rev-parse --short=8 HEAD`"
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gallactic/gallactic/rpc/grpc/proto3
 
@@ -18,7 +18,7 @@ ifeq ($(UNAME), Linux)
 CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -ldl -lssl -lcrypto -lpthread -lm"
 endif
 ifeq ($(UNAME), Darwin)
-CFLAGS=CGO_LDFLAGS="$(SPUTNIKVM_PATH)/c/libsputnikvm.a -framework CoreServices -framework Foundation -framework Security"
+CFLAGS=CGO_LDFLAGS="-framework Security $(SPUTNIKVM_PATH)/c/libsputnikvm.a "
 endif
 
 all: tools deps build install test test_release proto

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.8
+FROM alpine:edge
 
 ENV WORKING_DIR /gallactic
 

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -9,14 +9,14 @@ RUN apk add --no-cache bash libgcc
 
 ENV GOPATH /go
 ENV PATH "$PATH:/go/bin"
-RUN apk add --no-cache curl git go build-base rust cargo && \
+RUN apk add --no-cache curl git go build-base rust cargo openssl-dev && \
     mkdir -p /go/src/github.com/gallactic/gallactic/ && \
     cd /go/src/github.com/gallactic/gallactic/ && \
     git clone https://github.com/gallactic/gallactic/ . && \
     git checkout develop && \
     make tools deps build && \
     cp ./build/gallactic /usr/bin && \
-    apk del curl git go build-base rust cargo && \
+    apk del curl git go build-base rust cargo openssl-dev && \
     rm -rf /go /root/.cache /root/.cargo
 
 EXPOSE 46656

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:edge
+FROM alpine:latest
 
 ENV WORKING_DIR /gallactic
 


### PR DESCRIPTION
web3 crates needs to link with `crypto` and `ssl` libraries .